### PR TITLE
Relocating the ManifestOwnersPlugin from the gradle-contacts-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+*.iml
+.gradle/
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     // of the classpath, so it's very likely that just havine p4java in your path will prevent the
     // JVM from even running.
     compile 'com.perforce:p4java-jfrog:2011.1.297684'
-
+    compile 'com.netflix.nebula:gradle-contacts-plugin:1.12.+'
     compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
     testCompile 'com.netflix.nebula:nebula-test:1.12.+'
 }

--- a/src/main/groovy/nebula/plugin/info/InfoPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/InfoPlugin.groovy
@@ -1,6 +1,7 @@
 package nebula.plugin.info
 
 import nebula.plugin.info.basic.BasicInfoPlugin
+import nebula.plugin.info.basic.ManifestOwnersPlugin
 import nebula.plugin.info.ci.ContinuousIntegrationInfoPlugin
 import nebula.plugin.info.java.InfoJavaPlugin
 import nebula.plugin.info.reporting.InfoJarManifestPlugin
@@ -22,6 +23,7 @@ class InfoPlugin implements Plugin<Project> {
 
         // Collectors
         project.plugins.apply(BasicInfoPlugin)
+        project.plugins.apply(ManifestOwnersPlugin)
         project.plugins.apply(ScmInfoPlugin)
         project.plugins.apply(ContinuousIntegrationInfoPlugin)
         project.plugins.apply(InfoJavaPlugin)

--- a/src/main/groovy/nebula/plugin/info/basic/ManifestOwnersPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/basic/ManifestOwnersPlugin.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.info.basic
+import nebula.plugin.contacts.BaseContactsPlugin
+import nebula.plugin.info.InfoBrokerPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Take the contacts and apply them to the manifest, specifically "owners" and "notify". In the presence of the
+ * gradle-info-plugin, we'll publish to tags, Module-Owner and Module-Email. Module-Owner is a common separated
+ * list of all contacts that have the "owner" role (or no role). Module-Email is a common separated list of
+ * contacts that want to be notified when changes are made to this module, they have to have the role of "notify"
+ * (or no role). We're assuming that multiple owners are allowed, and we can just comma separate them.
+ */
+class ManifestOwnersPlugin implements Plugin<Project> {
+    public static final String OWNER_ROLE = 'owner'
+    public static final String NOTIFY_ROLE = 'notify'
+
+    @Override
+    void apply(Project project) {
+        // React to BaseContactsPlugin
+        project.plugins.withType(BaseContactsPlugin) { BaseContactsPlugin contactsPlugin ->
+            // React to Info Plugin
+            project.plugins.withType(InfoBrokerPlugin) { InfoBrokerPlugin basePlugin ->
+
+                basePlugin.add('Module-Owner') {
+                    contactsPlugin.getContacts(OWNER_ROLE).collect { it.email }.join(',')
+                }
+
+                basePlugin.add('Module-Email') {
+                    contactsPlugin.getContacts(NOTIFY_ROLE).collect { it.email }.join(',')
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/gradle-plugins/info-manifest.properties
+++ b/src/main/resources/META-INF/gradle-plugins/info-manifest.properties
@@ -1,0 +1,1 @@
+implementation-class=nebula.plugin.info.basic.ManifestOwnersPlugin

--- a/src/test/groovy/nebula/plugin/info/basic/ManifestOwnersPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/basic/ManifestOwnersPluginSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.info.basic
+import nebula.plugin.contacts.BaseContactsPlugin
+import nebula.plugin.info.InfoBrokerPlugin
+import nebula.test.PluginProjectSpec
+
+class ManifestOwnersPluginSpec extends PluginProjectSpec {
+    @Override
+    String getPluginName() {
+        'contacts-manifest'
+    }
+
+    def 'values in broker'() {
+        def contactsPlugin = project.plugins.apply(BaseContactsPlugin)
+        project.plugins.apply(ManifestOwnersPlugin)
+        def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
+        contactsPlugin.extension.addPerson('mickey@disney.com') {
+            moniker 'Mickey Mouse'
+            role 'owner'
+        }
+        contactsPlugin.extension.addPerson('minnie@disney.com')
+        contactsPlugin.extension.addPerson('goofy@disney.com') {
+            role 'notify'
+        }
+
+        when:
+        def manifest = brokerPlugin.buildManifest()
+
+        then:
+        manifest['Module-Owner'] == 'mickey@disney.com,minnie@disney.com'
+        manifest['Module-Email'] == 'minnie@disney.com,goofy@disney.com'
+
+    }
+}


### PR DESCRIPTION
Relocating the ManifestOwnersPlugin from the gradle-contacts-plugin to the gradle-info-plugin.  Adding a dependency on the gradle-contacts-plugin (reversing the plugin).  

Related PRs:
https://github.com/nebula-plugins/gradle-contacts-plugin/pull/2
https://github.com/nebula-plugins/nebula-publishing-plugin/pull/11
