### PR TITLE
Git Support: include full hash, not just first 7 characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea/
 *.iml
+*.ipr
+*.iws
 .gradle/
 build/

--- a/src/main/groovy/nebula/plugin/info/scm/GitScmProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/GitScmProvider.groovy
@@ -44,8 +44,7 @@ class GitScmProvider extends AbstractScmProvider {
             }
             hash = head.name
         }
-        def shortHash = hash?.substring(0,7)
-        return shortHash
+        return hash
     }
 
 }


### PR DESCRIPTION
When using the stored information to drive deployment automation, it's far preferable to store the full value to eliminate the chance of ambiguity due to collisions in the short hash.  If the application displays the value, it can present a truncated form based on the full value.
