### PR TITLE
Resolve #15: Update from older version of p4java-jfrog to latest versjon...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,7 @@ contacts {
 dependencies {
     // TODO, make these optional
 
-    // Specifically not using com.perforce:p4java since it has a META-INF/INDEX.LIST file that lists
-    // com.jcraft. In additional to wrongness of bundle thirdparty libraries, it doesn't even have 
-    // those class files. The classloader will consider the INDEX.LIST file depending on ordering
-    // of the classpath, so it's very likely that just havine p4java in your path will prevent the
-    // JVM from even running.
-    compile 'com.perforce:p4java-jfrog:2011.1.297684'
+    compile 'com.perforce:p4java:2014.1.965322'
     compile 'com.netflix.nebula:gradle-contacts-plugin:2.2.+'
     compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
     compile 'org.tmatesoft.svnkit:svnkit:1.8.5'

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,6 +1,6 @@
 {
   "com.netflix.nebula:gradle-contacts-plugin": { "locked": "2.2.0", "requested": "2.2.+" },
   "com.netflix.nebula:nebula-test": { "locked": "2.2.0", "requested": "2.2.+" },
-  "com.perforce:p4java-jfrog": { "locked": "2011.1.297684", "requested": "2011.1.297684" },
+  "com.perforce:p4java": { "locked": "2014.1.965322", "requested": "2014.1.965322" },
   "org.eclipse.jgit:org.eclipse.jgit": { "locked": "3.2.0.201312181205-r", "requested": "3.2.0.201312181205-r" }
 }


### PR DESCRIPTION
... of p4java, which does not have the problem that prompted the use of p4java-jfrog in the first place.

Note that I do not have access to a perforce repository, so testing has been limited to compiling and building (including running the project's unit tests).