### PR TITLE
Include timezone in Build-Date and date format in basic info

### DIFF
--- a/src/main/groovy/nebula/plugin/info/basic/BasicInfoPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/basic/BasicInfoPlugin.groovy
@@ -16,6 +16,7 @@ import static java.util.jar.Attributes.Name.*
  *     <li>Built-Status (project.status)</li>
  *     <li>Built-By (user.name)</li>
  *     <li>Build-Date</li>
+ *     <li>Build-Date-Format</li>
  *     <li>Gradle-Version (project.gradle.gradleVersion)</li>
  * </ul>
  */
@@ -48,8 +49,10 @@ class BasicInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
             manifestPlugin.add('Built-By', System.getProperty('user.name'))
             manifestPlugin.add('Built-OS', System.getProperty('os.name'))
 
+            String buildDateFormat = "yyyy-MM-dd'T'HH:mm:ssXXX"
             // Makes list of attributes not idempotent, which can throw off "changed" checks
-            manifestPlugin.add('Build-Date', new Date().format('yyyy-MM-dd_HH:mm:ss')).changing = true
+            manifestPlugin.add('Build-Date', new Date().format(buildDateFormat)).changing = true
+            manifestPlugin.add('Build-Date-Format', buildDateFormat)
 
             manifestPlugin.add('Gradle-Version', { project.gradle.gradleVersion })
 

--- a/src/test/groovy/nebula/plugin/info/reporting/InfoJarManifestPluginLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/reporting/InfoJarManifestPluginLauncherSpec.groovy
@@ -4,6 +4,7 @@ import nebula.plugin.info.InfoBrokerPlugin
 import nebula.plugin.info.basic.BasicInfoPlugin
 import nebula.test.IntegrationSpec
 
+import java.text.SimpleDateFormat
 import java.util.jar.Attributes
 import java.util.jar.JarFile
 import java.util.jar.Manifest
@@ -83,6 +84,12 @@ class InfoJarManifestPluginLauncherSpec extends IntegrationSpec {
         assertMainfestKeyExists(attributes, 'Built-By')
         assertMainfestKeyExists(attributes, 'Built-OS')
         assertMainfestKeyExists(attributes, 'Build-Date')
+        assertMainfestKeyExists(attributes, 'Build-Date-Format')
+        // ensure that the Build-Date can be parsed and the parsed Date formats to the Build-Date
+        SimpleDateFormat sdf = new SimpleDateFormat(manifestKey(attributes, 'Build-Date-Format'))
+        String manifestBuildDate = manifestKey(attributes, 'Build-Date')
+        Date buildDate = sdf.parse(manifestBuildDate)
+        sdf.format(buildDate) == manifestBuildDate
         assertMainfestKeyExists(attributes, 'Gradle-Version')
     }
 


### PR DESCRIPTION
This commit changes the format of the Build-Date in the jar manifest to
be formatted in ISO 8601 including the timezone offset. Additionally,
for convenience, the format used to represent the Build-Date is
included in the jar manifest.