### PR TITLE
Add upstream dependency graph to reports

### DIFF
--- a/src/main/groovy/nebula/plugin/info/InfoBrokerPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/InfoBrokerPlugin.groovy
@@ -116,10 +116,6 @@ class InfoBrokerPlugin implements Plugin<Project> {
             throw new IllegalStateException('Build reports should only be used from the root project')
         }
 
-        if (!buildFinished.get()) {
-            throw new IllegalStateException('Cannot retrieve build reports before the build has finished')
-        }
-
         return Collections.unmodifiableMap(reportEntries)
     }
 

--- a/src/main/groovy/nebula/plugin/info/dependencies/DependenciesInfoPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/dependencies/DependenciesInfoPlugin.groovy
@@ -20,39 +20,22 @@ import nebula.plugin.info.InfoCollectorPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 
 class DependenciesInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
-    def versionComparator = new DefaultVersionComparator().asStringComparator()
 
     @Override
     void apply(Project project) {
-        if (!project.rootProject.hasProperty('nebulaInfoDependencies')) {
-            project.rootProject.ext.nebulaInfoDependencies = [:]
-        }
-        def dependencyMap = project.rootProject.property('nebulaInfoDependencies')
         def dependencies = [:]
         project.plugins.withType(InfoBrokerPlugin) { InfoBrokerPlugin manifestPlugin ->
             project.configurations.all { Configuration conf ->
                 conf.incoming.afterResolve {
-                    def resolvedDependencies = it.resolutionResult.allComponents.findAll { it.id instanceof ModuleComponentIdentifier }*.moduleVersion
-                                .sort(true, { m1, m2 ->
-                                    if(m1.group != m2.group)
-                                        return m1.group?.compareTo(m2.group) ?: -1
-                                    if(m1.name != m2.name)
-                                        return m1.name.compareTo(m2.name) // name is required
-                                    versionComparator.compare(m1.version, m2.version)
-                                })*.toString().join(',')
-                    if (resolvedDependencies) {
-                        dependencies.put("Resolved-Dependencies-${it.name.capitalize()}", resolvedDependencies)
-                    }
+                    dependencies
+                        .put(it.name, it.resolutionResult.allDependencies)
                 }
             }
 
-            dependencyMap["${project.name}-dependencies".toString()] = dependencies
             if (project == project.rootProject) {
-                manifestPlugin.addReport('resolved-dependencies', dependencyMap)
+                manifestPlugin.addReport('dependencies', ["${project.name}": dependencies])
             }
         }
     }


### PR DESCRIPTION
Rather than submitting just the resolved dependencies, just dump the per-configuration set of `DependencyResult`s. This gives us the full dependency graph.

The existing spec for `DependencieInfoPlugin` is wrong. Those dependencies are not, as far as I can tell, being added to the manifest. Thus, I deleted the existing spec and made a new one for reports.