### PR TITLE
Report inputs to dependency resolution; improve outputs

### DIFF
--- a/src/test/groovy/nebula/plugin/info/InfoPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/InfoPluginIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class InfoPluginIntegrationSpec extends IntegrationSpec {
             def broker = project.plugins.getPlugin(${InfoBrokerPlugin.name})
 
             gradle.buildFinished {
-                println broker.buildReports().get('resolved-dependencies')
+                println broker.buildReports().get('resolvedDependencies')
             }
         """.stripIndent()
 
@@ -42,7 +42,7 @@ class InfoPluginIntegrationSpec extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully('assemble')
 
         then:
-        result.standardOutput.contains('-dependencies={Resolved-Dependencies-CompileClasspath=com.google.guava:guava:18.0}}')
+        result.standardOutput.contains('{it-returns-build-reports-at-the-end-of-the-build={compileClasspath=[com.google.guava:guava:18.0]}}')
     }
 
     def 'it returns build reports at the end of multiproject build'() {
@@ -59,7 +59,7 @@ class InfoPluginIntegrationSpec extends IntegrationSpec {
             def broker = project.plugins.getPlugin(${InfoBrokerPlugin.name})
 
             gradle.buildFinished {
-                println broker.buildReports().get('resolved-dependencies')
+                println broker.buildReports().get('resolvedDependencies')
             }
         """.stripIndent()
         def common = addSubproject('common', '''\
@@ -81,7 +81,6 @@ class InfoPluginIntegrationSpec extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully('build')
 
         then:
-        result.standardOutput.contains('common-dependencies={Resolved-Dependencies-CompileClasspath=com.google.guava:guava:18.0}')
-        result.standardOutput.contains('app-dependencies={Resolved-Dependencies-CompileClasspath=com.google.guava:guava:19.0}')
+        result.standardOutput.contains('{it-returns-build-reports-at-the-end-of-multiproject-build={}, app={compileClasspath=[com.google.guava:guava:19.0]}, common={compileClasspath=[com.google.guava:guava:18.0]}}')
     }
 }

--- a/src/test/groovy/nebula/plugin/info/dependency/DependenciesInfoPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/dependency/DependenciesInfoPluginSpec.groovy
@@ -19,22 +19,76 @@ import nebula.plugin.info.InfoBrokerPlugin
 import nebula.plugin.info.dependencies.DependenciesInfoPlugin
 import nebula.test.PluginProjectSpec
 import org.gradle.api.artifacts.ResolveException
+import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.StrictConflictResolution
 import spock.lang.Unroll
 
 class DependenciesInfoPluginSpec extends PluginProjectSpec {
-    def 'omits manifest entry if no dependencies'() {
+    def 'reports requestedDependencies if zero-sized'() {
         setup:
         project.apply plugin: 'java'
         def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
         project.apply plugin: DependenciesInfoPlugin
         project.configurations.compile.resolve()
 
+
         when:
-        def manifest = brokerPlugin.buildManifest()
+        brokerPlugin.buildFinished.set(true)
+        def reports = brokerPlugin.buildReports()
 
         then:
         noExceptionThrown()
-        !manifest.containsKey('Resolved-Dependencies-Compile')
+        reports.containsKey('requestedDependencies')
+    }
+
+    def 'reports resolvedDependencies if zero-sized'() {
+        setup:
+        project.apply plugin: 'java'
+        def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
+        project.apply plugin: DependenciesInfoPlugin
+        project.configurations.compile.resolve()
+
+
+        when:
+        brokerPlugin.buildFinished.set(true)
+        def reports = brokerPlugin.buildReports()
+
+        then:
+        noExceptionThrown()
+        reports.containsKey('resolvedDependencies')
+    }
+
+    def 'reports excludes if zero-sized'() {
+        setup:
+        project.apply plugin: 'java'
+        def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
+        project.apply plugin: DependenciesInfoPlugin
+        project.configurations.compile.resolve()
+
+
+        when:
+        brokerPlugin.buildFinished.set(true)
+        def reports = brokerPlugin.buildReports()
+
+        then:
+        noExceptionThrown()
+        reports.containsKey('excludes')
+    }
+
+    def 'reports resolutionStrategies if zero-sized'() {
+        setup:
+        project.apply plugin: 'java'
+        def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
+        project.apply plugin: DependenciesInfoPlugin
+        project.configurations.compile.resolve()
+
+
+        when:
+        brokerPlugin.buildFinished.set(true)
+        def reports = brokerPlugin.buildReports()
+
+        then:
+        noExceptionThrown()
+        reports.containsKey('resolutionStrategies')
     }
 
     def 'only includes configurations on configuration container'() {
@@ -63,7 +117,142 @@ class DependenciesInfoPluginSpec extends PluginProjectSpec {
         def reports = brokerPlugin.buildReports()
 
         then:
-        reports['resolved-dependencies']['only-includes-configurations-on-configuration-container-dependencies'].size() == 1
+        reports['resolvedDependencies']['only-includes-configurations-on-configuration-container'].size() == 1
+    }
+
+    def 'reports requestedDependencies'() {
+        setup:
+        project.apply plugin: 'java'
+        def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
+        project.apply plugin: DependenciesInfoPlugin
+
+        def spark = project.dependencies.create('org.apache.spark:spark-parent:1.2.2')
+
+        project.repositories.add(project.repositories.mavenCentral())
+
+        def configurations = project.configurations
+
+        def compile = configurations.compile
+        compile.dependencies.add(spark)
+
+        compile.resolve()
+
+        when:
+        brokerPlugin.buildFinished.set(true)
+        def reports = brokerPlugin.buildReports()
+
+        then:
+        noExceptionThrown()
+        reports['requestedDependencies']['reports-requestedDependencies']['compile'].size() == 1
+    }
+
+    def 'reports resolvedDependencies'() {
+        setup:
+        project.apply plugin: 'java'
+        def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
+        project.apply plugin: DependenciesInfoPlugin
+
+        def spark = project.dependencies.create('org.apache.spark:spark-parent:1.2.2')
+
+        project.repositories.add(project.repositories.mavenCentral())
+
+        def configurations = project.configurations
+
+        def compile = configurations.compile
+        compile.dependencies.add(spark)
+
+        compile.resolve()
+
+        when:
+        brokerPlugin.buildFinished.set(true)
+        def reports = brokerPlugin.buildReports()
+
+        then:
+        noExceptionThrown()
+        reports['resolvedDependencies']['reports-resolvedDependencies']['compile']
+            .findAll { it.moduleVersion.id.toString() == 'org.apache.spark:spark-parent' }
+            .size() == 1
+
+    }
+
+    def 'reports the dependency model per Gradle without transforming it'() {
+        setup:
+        project.apply plugin: 'java'
+        def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
+        project.apply plugin: DependenciesInfoPlugin
+
+        def spark = project.dependencies.create('org.apache.spark:spark-parent:1.2.2', {
+            exclude group: 'org.apache.spark', module: 'unused'
+        })
+
+        project.repositories.add(project.repositories.mavenCentral())
+
+        def configurations = project.configurations
+
+        def compile = configurations.compile
+        compile.dependencies.add(spark)
+
+        compile.resolve()
+
+        when:
+        brokerPlugin.buildFinished.set(true)
+        def reports = brokerPlugin.buildReports()
+
+        then:
+        noExceptionThrown()
+        // the excludes are attached via Gradle's own internal model
+        reports['requestedDependencies']['reports-the-dependency-model-per-Gradle-without-transforming-it']['compile'][0]
+            .getExcludeRules()
+            .size() == 1
+    }
+
+    def 'reports excludes'() {
+        project.apply plugin: 'java'
+        def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
+        project.apply plugin: DependenciesInfoPlugin
+
+        project.repositories.add(project.repositories.mavenCentral())
+
+        def configurations = project.configurations
+
+        def compile = configurations.compile
+        compile.exclude(["group": "org.apache.spark", "module": "spark-parent"])
+        compile.resolve()
+
+        when:
+        brokerPlugin.buildFinished.set(true)
+        def reports = brokerPlugin.buildReports()
+
+        then:
+        noExceptionThrown()
+        // the excludes are attached via Gradle's own internal model
+        reports['excludes']['reports-excludes']['compile'].size() == 1
+    }
+
+    def 'reports resolution strategies'() {
+        project.apply plugin: 'java'
+        def brokerPlugin = project.plugins.apply(InfoBrokerPlugin)
+        project.apply plugin: DependenciesInfoPlugin
+
+        project.repositories.add(project.repositories.mavenCentral())
+
+        def configurations = project.configurations
+
+        def compile = configurations.compile
+        compile.resolutionStrategy {
+            failOnVersionConflict()
+        }
+        compile.resolve()
+
+        when:
+        brokerPlugin.buildFinished.set(true)
+        def reports = brokerPlugin.buildReports()
+
+        then:
+        noExceptionThrown()
+        reports['resolutionStrategies']['reports-resolution-strategies']['compile']
+            .conflictResolution instanceof StrictConflictResolution
+
     }
 
     @Override


### PR DESCRIPTION
### CHANGES

Extends the current dependency reporting in two ways:
1. Resolved dependencies are now reported as a structured set of dependency objects, instead of a string of GAV identifiers
2. The following inputs to the dependency resolution process are added to reports: requested dependencies, excludes & resolution strategies.

### RATIONALE

Knowing more about build inputs and outputs can help to to measure the effectiveness of our strategies for managing dependencies & to run experiments. Downstream builder can use metrics as a source for projects that are actively building and looking for the latest release of a dependency.
