### PR TITLE
Add support for buildscript classpath dependencies to info report

### DIFF
--- a/src/test/groovy/nebula/plugin/info/InfoBrokerPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/InfoBrokerPluginIntegrationSpec.groovy
@@ -48,4 +48,5 @@ class InfoBrokerPluginIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains(report)
     }
 
+
 }


### PR DESCRIPTION
Hey folks, I discussed with @rahulsom a few weeks ago the potential inclusion of this into the build metrics. We capture resolved dependencies for each configuration but we don't for buildscript classpath and with many plugins it would be great if we could