### PR TITLE
Use ProviderFactory in order to support configuration cache

### DIFF
--- a/src/main/groovy/nebula/plugin/info/basic/BasicInfoPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/basic/BasicInfoPlugin.groovy
@@ -20,7 +20,9 @@ import nebula.plugin.info.InfoBrokerPlugin
 import nebula.plugin.info.InfoCollectorPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
 
+import javax.inject.Inject
 import java.text.SimpleDateFormat
 
 import static java.util.jar.Attributes.Name.*
@@ -55,6 +57,12 @@ class BasicInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
     // Implementation-Vendor-Id: org.apache
     // X-Compile-Source-JDK: 1.3
     // X-Compile-Target-JDK: 1.2
+    private final ProviderFactory providers
+
+    @Inject
+    BasicInfoPlugin(ProviderFactory providerFactory) {
+        this.providers = providerFactory
+    }
 
     void apply(Project project) {
 
@@ -64,8 +72,11 @@ class BasicInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
             manifestPlugin.add(IMPLEMENTATION_TITLE.toString()) { "${project.group}#${project.name};${project.version}" }.changing = true
             manifestPlugin.add(IMPLEMENTATION_VERSION.toString()) { project.version }
             manifestPlugin.add('Built-Status') { project.status } // Could be promoted, so this is the actual status necessarily
-            manifestPlugin.add('Built-By', System.getProperty('user.name'))
-            manifestPlugin.add('Built-OS', System.getProperty('os.name'))
+
+            String builtBy = providers.systemProperty("user.name").forUseAtConfigurationTime().get()
+            String builtOs = providers.systemProperty("os.name").forUseAtConfigurationTime().get()
+            manifestPlugin.add('Built-By', builtBy)
+            manifestPlugin.add('Built-OS', builtOs)
 
             // Makes list of attributes not idempotent, which can throw off "changed" checks
             manifestPlugin.add('Build-Date', DATE_FORMATTER.format(new Date())).changing = true

--- a/src/main/groovy/nebula/plugin/info/ci/AbstractContinuousIntegrationProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/AbstractContinuousIntegrationProvider.groovy
@@ -18,14 +18,22 @@ package nebula.plugin.info.ci
 
 import com.sun.jna.platform.win32.Kernel32Util
 import groovy.util.logging.Log
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.internal.os.OperatingSystem
 
 import java.util.logging.Level
 
 @Log
 abstract class AbstractContinuousIntegrationProvider implements ContinuousIntegrationInfoProvider {
-    protected static String getEnvironmentVariable(String envKey) {
-        System.getenv(envKey)
+
+    private final ProviderFactory providerFactory
+
+    AbstractContinuousIntegrationProvider(ProviderFactory providerFactory) {
+        this.providerFactory = providerFactory
+    }
+
+    protected String getEnvironmentVariable(String envKey) {
+        return providerFactory.environmentVariable(envKey).forUseAtConfigurationTime().present ? providerFactory.environmentVariable(envKey).forUseAtConfigurationTime().get() : null
     }
 
     protected static String hostname() {

--- a/src/main/groovy/nebula/plugin/info/ci/CircleCIProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/CircleCIProvider.groovy
@@ -16,8 +16,13 @@
 package nebula.plugin.info.ci
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
 
 class CircleCIProvider extends AbstractContinuousIntegrationProvider {
+    CircleCIProvider(ProviderFactory providerFactory) {
+        super(providerFactory)
+    }
+
     @Override
     boolean supports(Project project) {
         getEnvironmentVariable('CIRCLECI')

--- a/src/main/groovy/nebula/plugin/info/ci/ContinuousIntegrationInfoPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/ContinuousIntegrationInfoPlugin.groovy
@@ -23,6 +23,9 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
+import org.gradle.api.provider.ProviderFactory
+
+import javax.inject.Inject
 
 class ContinuousIntegrationInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
     protected Project project
@@ -30,11 +33,18 @@ class ContinuousIntegrationInfoPlugin implements Plugin<Project>, InfoCollectorP
     ContinuousIntegrationInfoProvider selectedProvider
     ContinuousIntegrationInfoExtension extension
 
+    private final ProviderFactory providerFactory
+
+    @Inject
+    ContinuousIntegrationInfoPlugin(ProviderFactory providerFactory) {
+        this.providerFactory = providerFactory
+    }
+
     @Override
     void apply(Project project) {
         this.project = project
 
-        providers = [new CircleCIProvider(), new DroneProvider(), new GitlabProvider(), new JenkinsProvider(), new TravisProvider(), new UnknownContinuousIntegrationProvider()] as List<ContinuousIntegrationInfoProvider>
+        providers = [new CircleCIProvider(providerFactory), new DroneProvider(providerFactory), new GitlabProvider(providerFactory), new JenkinsProvider(providerFactory), new TravisProvider(providerFactory), new UnknownContinuousIntegrationProvider(providerFactory)] as List<ContinuousIntegrationInfoProvider>
         selectedProvider = findProvider()
 
         extension = project.extensions.create('ciinfo', ContinuousIntegrationInfoExtension)

--- a/src/main/groovy/nebula/plugin/info/ci/DroneProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/DroneProvider.groovy
@@ -16,8 +16,15 @@
 package nebula.plugin.info.ci
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
+
 
 class DroneProvider extends AbstractContinuousIntegrationProvider {
+
+    DroneProvider(ProviderFactory providerFactory) {
+        super(providerFactory)
+    }
+
     @Override
     boolean supports(Project project) {
         getEnvironmentVariable('DRONE')

--- a/src/main/groovy/nebula/plugin/info/ci/GitlabProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/GitlabProvider.groovy
@@ -17,8 +17,13 @@
 package nebula.plugin.info.ci
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
 
 class GitlabProvider extends AbstractContinuousIntegrationProvider {
+
+    GitlabProvider(ProviderFactory providerFactory) {
+        super(providerFactory)
+    }
 
     @Override
     boolean supports(Project project) {

--- a/src/main/groovy/nebula/plugin/info/ci/JenkinsProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/JenkinsProvider.groovy
@@ -17,8 +17,13 @@
 package nebula.plugin.info.ci
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
 
 class JenkinsProvider extends AbstractContinuousIntegrationProvider {
+
+    JenkinsProvider(ProviderFactory providerFactory) {
+        super(providerFactory)
+    }
 
     @Override
     boolean supports(Project project) {

--- a/src/main/groovy/nebula/plugin/info/ci/TravisProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/TravisProvider.groovy
@@ -16,8 +16,13 @@
 package nebula.plugin.info.ci
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
 
 class TravisProvider extends AbstractContinuousIntegrationProvider {
+    TravisProvider(ProviderFactory providerFactory) {
+        super(providerFactory)
+    }
+
     @Override
     boolean supports(Project project) {
         getEnvironmentVariable('TRAVIS')

--- a/src/main/groovy/nebula/plugin/info/ci/UnknownContinuousIntegrationProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/UnknownContinuousIntegrationProvider.groovy
@@ -17,9 +17,14 @@
 package nebula.plugin.info.ci
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
 
 class UnknownContinuousIntegrationProvider extends AbstractContinuousIntegrationProvider {
     public static final String LOCAL = 'LOCAL'
+
+    UnknownContinuousIntegrationProvider(ProviderFactory providerFactory) {
+        super(providerFactory)
+    }
 
     @Override
     boolean supports(Project project) {

--- a/src/main/groovy/nebula/plugin/info/scm/AbstractScmProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/AbstractScmProvider.groovy
@@ -17,10 +17,21 @@
 package nebula.plugin.info.scm
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
 
 
 abstract class AbstractScmProvider implements ScmInfoProvider {
     abstract calculateModuleSource(File projectDir)
+
+    private final ProviderFactory providerFactory
+
+    AbstractScmProvider(ProviderFactory providerFactory) {
+        this.providerFactory = providerFactory
+    }
+
+    protected ProviderFactory getProviderFactory() {
+        return this.providerFactory
+    }
 
     @Override
     String calculateSource(Project project) {

--- a/src/main/groovy/nebula/plugin/info/scm/ScmInfoPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/ScmInfoPlugin.groovy
@@ -25,6 +25,9 @@ import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.provider.ProviderFactory
+
+import javax.inject.Inject
 
 class ScmInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
     private static Logger logger = Logging.getLogger(ScmInfoPlugin)
@@ -34,12 +37,19 @@ class ScmInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
     ScmInfoProvider selectedProvider
     ScmInfoExtension extension
 
+    private final ProviderFactory providerFactory
+
+    @Inject
+    ScmInfoPlugin(ProviderFactory providerFactory) {
+        this.providerFactory = providerFactory
+    }
+
     @Override
     void apply(Project project) {
         this.project = project
 
         // TODO Delay findProvider() as long as possible
-        providers = [new GitScmProvider(), new PerforceScmProvider(), new SvnScmProvider(), new UnknownScmProvider()] as List<ScmInfoProvider>
+        providers = [new GitScmProvider(providerFactory), new PerforceScmProvider(providerFactory), new SvnScmProvider(providerFactory), new UnknownScmProvider(providerFactory)] as List<ScmInfoProvider>
         selectedProvider = findProvider()
 
         extension = project.extensions.create('scminfo', ScmInfoExtension)

--- a/src/main/groovy/nebula/plugin/info/scm/SvnScmProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/SvnScmProvider.groovy
@@ -17,10 +17,15 @@
 package nebula.plugin.info.scm
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
 import org.tmatesoft.svn.core.internal.wc.DefaultSVNOptions
 import org.tmatesoft.svn.core.wc.*
 
 class SvnScmProvider extends AbstractScmProvider {
+
+    SvnScmProvider(ProviderFactory providerFactory) {
+        super(providerFactory)
+    }
 
     @Override
     boolean supports(Project project) {
@@ -51,13 +56,16 @@ class SvnScmProvider extends AbstractScmProvider {
 
     @Override
     String calculateChange(File projectDir) {
-        String revision = System.getenv('SVN_REVISION') // From Jenkins
-        if (!revision) {
+        boolean isRevisionPresent = providerFactory.environmentVariable('SVN_REVISION').forUseAtConfigurationTime().present
+        String revision
+        if (!isRevisionPresent) {
             def base = getInfo(projectDir).getRevision()
             if (!base) {
                 return null
             }
             revision = base.getNumber()
+        } else {
+            revision = providerFactory.environmentVariable('SVN_REVISION').forUseAtConfigurationTime().get()
         }
         return revision
     }

--- a/src/main/groovy/nebula/plugin/info/scm/UnknownScmProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/UnknownScmProvider.groovy
@@ -17,10 +17,15 @@
 package nebula.plugin.info.scm
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
 
 class UnknownScmProvider extends AbstractScmProvider {
 
     public static final String LOCAL = 'LOCAL'
+
+    UnknownScmProvider(ProviderFactory providerFactory) {
+        super(providerFactory)
+    }
 
     @Override
     boolean supports(Project project) {

--- a/src/test/groovy/nebula/plugin/info/scm/PerforceScmProviderSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/scm/PerforceScmProviderSpec.groovy
@@ -15,6 +15,8 @@
  */
 package nebula.plugin.info.scm
 
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.rules.TemporaryFolder
@@ -24,7 +26,10 @@ class PerforceScmProviderSpec extends Specification {
     @Rule
     TemporaryFolder temp
 
-    def provider = new PerforceScmProvider()
+    ProviderFactory providerFactoryMock = Mock(ProviderFactory)
+    Provider<String> providerStringMock = Mock(Provider)
+
+    def provider = new PerforceScmProvider(providerFactoryMock)
 
     @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
@@ -107,11 +112,20 @@ class PerforceScmProviderSpec extends Specification {
         then:
         mapped == '//depot/Tools/nebula-boot'
 
+        2 * providerFactoryMock.environmentVariable('WORKSPACE') >> providerStringMock
+        2 * providerStringMock.forUseAtConfigurationTime() >> providerStringMock
+        1 * providerStringMock.present >> true
+        1 * providerStringMock.get() >> workspace.path
+
         when:
         String origin = provider.calculateModuleOrigin(fakeProjectDir)
 
         then:
         origin == 'p4java://perforce:1666?userName=rolem'
+
+        1 * providerFactoryMock.environmentVariable('P4CONFIG') >> providerStringMock
+        1 * providerStringMock.forUseAtConfigurationTime() >> providerStringMock
+        1 * providerStringMock.get() >> fakeProjectDir.path
     }
 
     def 'calculate module status - WORKSPACE is null'() {
@@ -127,10 +141,19 @@ class PerforceScmProviderSpec extends Specification {
         then:
         mapped == '//depot//Users/jryan/Workspaces/jryan_uber/Tools/nebula-boot'
 
+        1 * providerFactoryMock.environmentVariable('WORKSPACE') >> providerStringMock
+        1 * providerStringMock.forUseAtConfigurationTime() >> providerStringMock
+        1 * providerStringMock.present >> false
+        0 * providerStringMock.get()
+
         when:
         String origin = provider.calculateModuleOrigin(fakeProjectDir)
 
         then:
         origin == 'p4java://perforce:1666?userName=rolem'
+
+        1 * providerFactoryMock.environmentVariable('P4CONFIG') >> providerStringMock
+        1 * providerStringMock.forUseAtConfigurationTime() >> providerStringMock
+        1 * providerStringMock.get() >> fakeProjectDir.path
     }
 }


### PR DESCRIPTION
Introduce usage of `ProviderFactory` to read env/system properties and try to be compatible with https://docs.gradle.org/6.5/userguide/configuration_cache.html