### PR TITLE
Add configuration cache support

### DIFF
--- a/src/main/groovy/nebula/plugin/info/InfoBrokerPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/InfoBrokerPlugin.groovy
@@ -17,15 +17,11 @@
 package nebula.plugin.info
 
 import groovy.transform.Canonical
-import org.gradle.BuildAdapter
-import org.gradle.BuildResult
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Broker between Collectors and Reporters. Collectors report to this plugin about manifest values,
@@ -41,7 +37,6 @@ class InfoBrokerPlugin implements Plugin<Project> {
     private List<ManifestEntry> manifestEntries
     private Map<String, Collection<Closure>> watchers
     private Map<String, Object> reportEntries
-    private AtomicBoolean buildFinished = new AtomicBoolean(false)
     private Project project
 
     void apply(Project project) {
@@ -51,14 +46,6 @@ class InfoBrokerPlugin implements Plugin<Project> {
         this.project = project
 
         InfoBrokerPluginExtension extension = project.getExtensions().create('infoBroker', InfoBrokerPluginExtension)
-
-        project.rootProject.gradle.addBuildListener(new BuildAdapter() {
-            @Override
-            void buildFinished(BuildResult buildResult) {
-                buildFinished.set(true)
-            }
-        })
-
         project.afterEvaluate {
             filterManifestEntries(extension)
         }
@@ -145,10 +132,6 @@ class InfoBrokerPlugin implements Plugin<Project> {
     Map<String, Object> buildReports() {
         if (project != project.rootProject) {
             throw new IllegalStateException('Build reports should only be used from the root project')
-        }
-
-        if (!buildFinished.get()) {
-            throw new IllegalStateException('Cannot retrieve build reports before the build has finished')
         }
 
         return Collections.unmodifiableMap(reportEntries)

--- a/src/test/groovy/nebula/plugin/info/InfoBrokerPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/InfoBrokerPluginSpec.groovy
@@ -102,19 +102,6 @@ class InfoBrokerPluginSpec extends ProjectSpec {
         attrs3['MyKey'] == 'MyValue' // Still around
     }
 
-    def 'it throws an exception when build reports are requested prior to build end'() {
-        given:
-        project.apply plugin: InfoBrokerPlugin
-
-        when:
-        def infoBrokerPlugin = project.plugins.getPlugin(InfoBrokerPlugin)
-        infoBrokerPlugin.addReport('test', 'some value')
-        def reports = infoBrokerPlugin.buildReports()
-
-        then:
-        thrown IllegalStateException
-    }
-
     def 'can not add multiple values'() {
         when:
         InfoBrokerPlugin broker = project.plugins.apply(InfoBrokerPlugin)

--- a/src/test/groovy/nebula/plugin/info/InfoPluginConfigurationCacheSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/InfoPluginConfigurationCacheSpec.groovy
@@ -1,0 +1,24 @@
+package nebula.plugin.info
+
+import nebula.test.IntegrationTestKitSpec
+
+class InfoPluginConfigurationCacheSpec extends IntegrationTestKitSpec {
+
+    def 'plugin applies with configuration cache'() {
+        buildFile << """
+        plugins {
+            id 'nebula.info'
+            id 'java'
+        }
+        """
+        writeHelloWorld('nebula.app')
+
+
+        when:
+        runTasks('--configuration-cache', 'compileJava', '-s')
+        def result = runTasks('--configuration-cache', 'compileJava', '-s')
+
+        then:
+        result.output.contains('Reusing configuration cache')
+    }
+}

--- a/src/test/groovy/nebula/plugin/info/dependency/DependenciesInfoPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/dependency/DependenciesInfoPluginSpec.groovy
@@ -62,7 +62,6 @@ class DependenciesInfoPluginSpec extends PluginProjectSpec {
         configurations.compileClasspath.resolve()
 
         when:
-        brokerPlugin.buildFinished.set(true)
         def reports = brokerPlugin.buildReports()
 
         then:


### PR DESCRIPTION
I found that the listener was creating configuration cache issues

I played around with build services as follows:

```
abstract static class InfoBrokerBuildService implements BuildService<Params>, OperationCompletionListener {
    interface Params extends BuildServiceParameters {
        Property<AtomicBoolean> getBooleanProperty()
    }

    @Override
    void onFinish(FinishEvent finishEvent) {
       //do something here
    }
}


def service = project.gradle.sharedServices.registerIfAbsent("infoBrokerBuildService", InfoBrokerBuildService) { BuildServiceSpec<InfoBrokerBuildService.Params> spec ->
    spec.parameters.booleanProperty.set(myAtomicBoolean)
}
registry.onTaskCompletion(service)

```

However, the usage of the listener seems like an anti-pattern where a property in the class is modified when the build is finished.

The build services are `OperationCompletionListener`s that are subscribed to task events. In addition, they can be mark as `Autoclosable` and get access to the `close()` method before tearing down the build. 

I don't think it is possible to access the service after that so we lose the state of the build here.

I'll check with Gradle folks in better ergonomics... really would like to have an event for when the buidl finishes, similar to https://github.com/gradle/gradle/blob/master/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskFinishEvent.java

For now, I believe removing this property is a good move from this pattern anyway as we shouldn't call the manifest directly before the build is executed.