### PR TITLE
Handle auth token in git repo url

### DIFF
--- a/src/main/groovy/nebula/plugin/info/scm/GitScmProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/GitScmProvider.groovy
@@ -90,10 +90,10 @@ class GitScmProvider extends AbstractScmProvider {
         try {
             String credentials = url.toURL().getUserInfo()
             if (credentials) {
-                return url.replaceFirst(credentials, credentials.replaceFirst(/:.*/, ""))
+                return url.replaceFirst(Pattern.quote(credentials), credentials.replaceFirst(/:.*/, ""))
             }
         } catch (Exception e) {
-            logger.warn("Unable to remove credentials from repository URL. {0}", e.getMessage())
+            logger.warn("Unable to remove credentials from repository URL. {}", e.getMessage())
         }
         return url
     }


### PR DESCRIPTION
If the repo the project is being stored in uses bitbucket cloud and it is checked out with an oauth token such as how jenkins does it the credentials string looks like a regex.  This breaks a sanitizing function in GitScmProvider.

For example a url like:  https://x-token-auth:{dKkmJHindwdsaw23-dsaHds5-_jjUBF3-S%c9f}@bitbucket.org/some-org/project.git

This change Pattern.quote()'s the http/https credentials when using them as the search string in String.replaceFirst.  It also fixes the exception handler for the method so it actually shows the exception message instead of "{0}" when this error occurs.
Fix log to show actual error for bad url