### PR TITLE
InfoJarPropertiesFilePlugin: remove the need for renaming temp.properties file so the jar tasks are cacheable

### DIFF
--- a/src/test/groovy/nebula/plugin/info/reporting/InfoJarManifestPluginLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/reporting/InfoJarManifestPluginLauncherSpec.groovy
@@ -231,6 +231,7 @@ class InfoJarManifestPluginLauncherSpec extends IntegrationSpec {
         buildFile << """
             ${applyPlugin(InfoBrokerPlugin)}
             ${applyPlugin(BasicInfoPlugin)}
+            ${applyPlugin(InfoJarPropertiesFilePlugin)}
             ${applyPlugin(InfoJarManifestPlugin)}
 
             apply plugin: 'java'


### PR DESCRIPTION
This fixes cacheability problems with jar task 