### PR TITLE
Configuration Cache Compatibility

### DIFF
--- a/src/main/groovy/nebula/plugin/info/ci/AbstractContinuousIntegrationProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/AbstractContinuousIntegrationProvider.groovy
@@ -33,7 +33,7 @@ abstract class AbstractContinuousIntegrationProvider implements ContinuousIntegr
     }
 
     protected String getEnvironmentVariable(String envKey) {
-        return providerFactory.environmentVariable(envKey).forUseAtConfigurationTime().present ? providerFactory.environmentVariable(envKey).forUseAtConfigurationTime().get() : null
+        return providerFactory.environmentVariable(envKey).present ? providerFactory.environmentVariable(envKey).get() : null
     }
 
     protected static String hostname() {

--- a/src/main/groovy/nebula/plugin/info/java/InfoJavaPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/java/InfoJavaPlugin.groovy
@@ -52,9 +52,9 @@ class InfoJavaPlugin implements Plugin<Project>, InfoCollectorPlugin {
 
     void apply(Project project) {
         // This can't change, so we can commit it early
-        project.plugins.withType(InfoBrokerPlugin) { InfoBrokerPlugin  manifestPlugin ->
-            String javaRuntimeVersion = providers.systemProperty("java.runtime.version").forUseAtConfigurationTime().get()
-            String javaVmVendor = providers.systemProperty("java.vm.vendor").forUseAtConfigurationTime().get()
+        project.plugins.withType(InfoBrokerPlugin) { InfoBrokerPlugin manifestPlugin ->
+            String javaRuntimeVersion = providers.systemProperty("java.runtime.version").get()
+            String javaVmVendor = providers.systemProperty("java.vm.vendor").get()
 
             manifestPlugin.add(CREATED_PROPERTY, "$javaRuntimeVersion ($javaVmVendor)")
         }
@@ -62,16 +62,15 @@ class InfoJavaPlugin implements Plugin<Project>, InfoCollectorPlugin {
         // After-evaluating, because we need to give user a chance to effect the extension
         project.afterEvaluate {
             project.plugins.withType(JavaBasePlugin) {
-                JavaPluginExtension javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
-
                 project.plugins.withType(InfoBrokerPlugin) { InfoBrokerPlugin manifestPlugin ->
-                    manifestPlugin.add(TARGET_PROPERTY, { javaPluginExtension.targetCompatibility } )
-                    manifestPlugin.add(SOURCE_PROPERTY, { javaPluginExtension.sourceCompatibility } )
+                    JavaPluginExtension javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
+                    manifestPlugin.add(TARGET_PROPERTY, javaPluginExtension.targetCompatibility)
+                    manifestPlugin.add(SOURCE_PROPERTY, javaPluginExtension.sourceCompatibility)
                     Provider<JavaLauncher> javaLauncher = getJavaLauncher(project)
-                    if(javaLauncher.isPresent()) {
+                    if (javaLauncher.isPresent()) {
                         manifestPlugin.add(JDK_PROPERTY, javaLauncher.get().metadata.languageVersion.toString())
                     } else {
-                        String javaVersionFromSystemProperty = providers.systemProperty("java.version").forUseAtConfigurationTime().get()
+                        String javaVersionFromSystemProperty = providers.systemProperty("java.version").get()
                         manifestPlugin.add(JDK_PROPERTY, javaVersionFromSystemProperty)
                     }
                 }

--- a/src/main/groovy/nebula/plugin/info/reporting/InfoJarPropertiesFilePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/reporting/InfoJarPropertiesFilePlugin.groovy
@@ -21,21 +21,34 @@ import groovy.transform.CompileDynamic
 import nebula.plugin.info.InfoBrokerPlugin
 import nebula.plugin.info.InfoPlugin
 import nebula.plugin.info.InfoReporterPlugin
+import nebula.plugin.info.basic.BasicInfoPlugin
 import org.gradle.api.Action
+import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.normalization.MetaInfNormalization
+
+import javax.inject.Inject
 
 /**
  * Inject a properties file into the jar file will the info values, using the InfoPropertiesFilePlugin
  */
 @CompileDynamic
 class InfoJarPropertiesFilePlugin implements Plugin<Project>, InfoReporterPlugin {
+    private InfoBrokerPlugin infoBrokerPlugin
+
+    @Inject
+    InfoJarPropertiesFilePlugin(Project project) {
+        infoBrokerPlugin = project.plugins.getPlugin(InfoBrokerPlugin) as InfoBrokerPlugin
+    }
 
     void apply(Project project) {
         project.plugins.withType(JavaBasePlugin) {
@@ -44,12 +57,9 @@ class InfoJarPropertiesFilePlugin implements Plugin<Project>, InfoReporterPlugin
                 TaskProvider<InfoPropertiesFile> manifestTask = propFilePlugin.getManifestTask()
 
                 File propertiesFile = new File(project.buildDir, "properties_for_jar/${manifestTask.get().propertiesFile.name}")
-                TaskProvider<Task> prepareFile = project.tasks.register("createPropertiesFileForJar") { Task task ->
-                    task.outputs.file(propertiesFile)
-                    task.doLast {
-                        //Task action is intentionally creating empty file.
-                        propertiesFile.text = ""
-                    }
+
+                TaskProvider<CreateEmptyPropertiesFile> prepareFile = project.tasks.register("createPropertiesFileForJar", CreateEmptyPropertiesFile) { CreateEmptyPropertiesFile task ->
+                    task.outputFile.set(propertiesFile)
                 }
 
                 project.tasks.withType(Jar).configureEach { Jar jarTask ->
@@ -65,7 +75,7 @@ class InfoJarPropertiesFilePlugin implements Plugin<Project>, InfoReporterPlugin
 
                     jarTask.doFirst {
                         //when we are after all caching decisions we fill the file with all the data
-                        new PropertiesWriter().writeProperties(propertiesFile, project)
+                        PropertiesWriter.writeProperties(propertiesFile, infoBrokerPlugin)
                     }
                     jarTask.doLast {
                         //we need to cleanup file in case we got multiple jar tasks
@@ -79,6 +89,16 @@ class InfoJarPropertiesFilePlugin implements Plugin<Project>, InfoReporterPlugin
             }
         }
 
+    }
+
+    abstract static class CreateEmptyPropertiesFile extends DefaultTask {
+        @OutputFile
+        abstract RegularFileProperty getOutputFile()
+
+        @TaskAction
+        void create() {
+            getOutputFile().get().asFile.text = ""
+        }
     }
 
     private static void configureMetaInfNormalization(Project project) {

--- a/src/main/groovy/nebula/plugin/info/reporting/InfoPropertiesFile.groovy
+++ b/src/main/groovy/nebula/plugin/info/reporting/InfoPropertiesFile.groovy
@@ -16,22 +16,32 @@
 
 package nebula.plugin.info.reporting
 
+import groovy.transform.CompileDynamic
 import nebula.plugin.info.InfoBrokerPlugin
+import nebula.plugin.info.basic.BasicInfoPlugin
+import org.gradle.api.Project
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
+import javax.inject.Inject
+
 /**
  * Simply writes out brokers values to a properties file.
  */
+@CompileDynamic
 class InfoPropertiesFile extends ConventionTask {
+    private InfoBrokerPlugin infoBrokerPlugin
+
+    @Inject
+    InfoPropertiesFile(Project project) {
+        infoBrokerPlugin = project.plugins.getPlugin(InfoBrokerPlugin) as InfoBrokerPlugin
+    }
 
     @Input
     Map<String, ?> getManifest() {
-        InfoBrokerPlugin manifestPlugin = project.plugins.getPlugin(InfoBrokerPlugin) as InfoBrokerPlugin
-
-        Map<String, String> entireMap = manifestPlugin.buildNonChangingManifest()
+        Map<String, String> entireMap = infoBrokerPlugin.buildNonChangingManifest()
 
         return entireMap
     }
@@ -41,6 +51,6 @@ class InfoPropertiesFile extends ConventionTask {
 
     @TaskAction
     void write() {
-        new PropertiesWriter().writeProperties(getPropertiesFile(), project)
+        PropertiesWriter.writeProperties(getPropertiesFile(), infoBrokerPlugin)
     }
 }

--- a/src/main/groovy/nebula/plugin/info/reporting/PropertiesWriter.groovy
+++ b/src/main/groovy/nebula/plugin/info/reporting/PropertiesWriter.groovy
@@ -4,10 +4,10 @@ import nebula.plugin.info.InfoBrokerPlugin
 import org.gradle.api.Project
 
 class PropertiesWriter {
+    private PropertiesWriter() {
+    }
 
-    void writeProperties(File location, Project project) {
-        InfoBrokerPlugin basePlugin = project.plugins.getPlugin(InfoBrokerPlugin) as InfoBrokerPlugin
-
+    static void writeProperties(File location, InfoBrokerPlugin basePlugin) {
         // Gather all values, in contrast to buildNonChangingManifest
         Map<String, String> attrs = basePlugin.buildManifest()
 

--- a/src/main/groovy/nebula/plugin/info/scm/GitScmProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/GitScmProvider.groovy
@@ -26,8 +26,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class GitScmProvider extends AbstractScmProvider {
-    private Logger logger = LoggerFactory.getLogger(GitScmProvider)
-
     GitScmProvider(ProviderFactory providerFactory) {
         super(providerFactory)
     }
@@ -73,7 +71,7 @@ class GitScmProvider extends AbstractScmProvider {
 
     @Override
     String calculateFullChange(File projectDir) {
-        boolean isHashPresent = providerFactory.environmentVariable('GIT_COMMIT').forUseAtConfigurationTime().present
+        boolean isHashPresent = providerFactory.environmentVariable('GIT_COMMIT').present
         String hash
         if (!isHashPresent) {
             def head = getRepository(projectDir).resolve(Constants.HEAD)
@@ -82,7 +80,7 @@ class GitScmProvider extends AbstractScmProvider {
             }
             hash = head.name
         } else {
-            hash = providerFactory.environmentVariable('GIT_COMMIT').forUseAtConfigurationTime().get()
+            hash = providerFactory.environmentVariable('GIT_COMMIT').get()
         }
         return hash
     }

--- a/src/main/groovy/nebula/plugin/info/scm/PerforceScmProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/PerforceScmProvider.groovy
@@ -43,7 +43,7 @@ class PerforceScmProvider extends AbstractScmProvider {
         // Better to check git first, since it can make a more intelligent guess
         // TODO When we can make p4java optional, we'll add a classForName check here.
         try {
-            return (providerFactory.environmentVariable('WORKSPACE').forUseAtConfigurationTime().present &&  providerFactory.environmentVariable('P4CLIENT').forUseAtConfigurationTime().present) || findFile(project.projectDir, providerFactory.environmentVariable('P4CONFIG').forUseAtConfigurationTime().get())
+            return (providerFactory.environmentVariable('WORKSPACE').present &&  providerFactory.environmentVariable('P4CLIENT').present) || findFile(project.projectDir, providerFactory.environmentVariable('P4CONFIG').get())
         } catch(Exception e) {
             return false
         }
@@ -51,7 +51,7 @@ class PerforceScmProvider extends AbstractScmProvider {
 
     @Override
     String calculateModuleSource(File projectDir) {
-        String workspacePath = providerFactory.environmentVariable('WORKSPACE').forUseAtConfigurationTime().present ? providerFactory.environmentVariable('WORKSPACE').forUseAtConfigurationTime().get() : {
+        String workspacePath = providerFactory.environmentVariable('WORKSPACE').present ? providerFactory.environmentVariable('WORKSPACE').get() : {
             logger.info("WORKSPACE environment variable is not set. Using ${DEFAULT_WORKSPACE}")
             DEFAULT_WORKSPACE
         }.call()
@@ -73,7 +73,7 @@ class PerforceScmProvider extends AbstractScmProvider {
 
     @Override
     String calculateChange(File projectDir) {
-        return  providerFactory.environmentVariable('P4_CHANGELIST').forUseAtConfigurationTime().get()
+        return  providerFactory.environmentVariable('P4_CHANGELIST').get()
     }
 
     @Override
@@ -165,7 +165,7 @@ class PerforceScmProvider extends AbstractScmProvider {
     @PackageScope
     void findP4Config(File starting) {
         if (p4configFile == null) {
-            p4configFile = findFile(starting, providerFactory.environmentVariable('P4CONFIG').forUseAtConfigurationTime().get())
+            p4configFile = findFile(starting, providerFactory.environmentVariable('P4CONFIG').get())
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/info/scm/SvnScmProvider.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/SvnScmProvider.groovy
@@ -56,7 +56,7 @@ class SvnScmProvider extends AbstractScmProvider {
 
     @Override
     String calculateChange(File projectDir) {
-        boolean isRevisionPresent = providerFactory.environmentVariable('SVN_REVISION').forUseAtConfigurationTime().present
+        boolean isRevisionPresent = providerFactory.environmentVariable('SVN_REVISION').present
         String revision
         if (!isRevisionPresent) {
             def base = getInfo(projectDir).getRevision()
@@ -65,7 +65,7 @@ class SvnScmProvider extends AbstractScmProvider {
             }
             revision = base.getNumber()
         } else {
-            revision = providerFactory.environmentVariable('SVN_REVISION').forUseAtConfigurationTime().get()
+            revision = providerFactory.environmentVariable('SVN_REVISION').get()
         }
         return revision
     }

--- a/src/test/groovy/nebula/plugin/info/InfoPluginConfigurationCacheSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/InfoPluginConfigurationCacheSpec.groovy
@@ -15,10 +15,11 @@ class InfoPluginConfigurationCacheSpec extends IntegrationTestKitSpec {
 
 
         when:
-        runTasks('--configuration-cache', 'compileJava', '-s')
-        def result = runTasks('--configuration-cache', 'compileJava', '-s')
+        runTasks('--configuration-cache', 'jar', '-s')
+        def result = runTasks('--configuration-cache', 'jar', '-s')
 
         then:
         result.output.contains('Reusing configuration cache')
     }
+
 }

--- a/src/test/groovy/nebula/plugin/info/reporting/InfoJarManifestPluginLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/reporting/InfoJarManifestPluginLauncherSpec.groovy
@@ -226,6 +226,7 @@ class InfoJarManifestPluginLauncherSpec extends IntegrationSpec {
     }
 
     def "changes to group and version after project evaluation are reflected"() {
+        fork = false
         given:
         writeHelloWorld('nebula.test')
         buildFile << """

--- a/src/test/groovy/nebula/plugin/info/scm/PerforceScmProviderSpec.groovy
+++ b/src/test/groovy/nebula/plugin/info/scm/PerforceScmProviderSpec.groovy
@@ -113,7 +113,6 @@ class PerforceScmProviderSpec extends Specification {
         mapped == '//depot/Tools/nebula-boot'
 
         2 * providerFactoryMock.environmentVariable('WORKSPACE') >> providerStringMock
-        2 * providerStringMock.forUseAtConfigurationTime() >> providerStringMock
         1 * providerStringMock.present >> true
         1 * providerStringMock.get() >> workspace.path
 
@@ -124,7 +123,6 @@ class PerforceScmProviderSpec extends Specification {
         origin == 'p4java://perforce:1666?userName=rolem'
 
         1 * providerFactoryMock.environmentVariable('P4CONFIG') >> providerStringMock
-        1 * providerStringMock.forUseAtConfigurationTime() >> providerStringMock
         1 * providerStringMock.get() >> fakeProjectDir.path
     }
 
@@ -142,7 +140,6 @@ class PerforceScmProviderSpec extends Specification {
         mapped == '//depot//Users/jryan/Workspaces/jryan_uber/Tools/nebula-boot'
 
         1 * providerFactoryMock.environmentVariable('WORKSPACE') >> providerStringMock
-        1 * providerStringMock.forUseAtConfigurationTime() >> providerStringMock
         1 * providerStringMock.present >> false
         0 * providerStringMock.get()
 
@@ -153,7 +150,6 @@ class PerforceScmProviderSpec extends Specification {
         origin == 'p4java://perforce:1666?userName=rolem'
 
         1 * providerFactoryMock.environmentVariable('P4CONFIG') >> providerStringMock
-        1 * providerStringMock.forUseAtConfigurationTime() >> providerStringMock
         1 * providerStringMock.get() >> fakeProjectDir.path
     }
 }


### PR DESCRIPTION
Expands compatibility to `jar` tasks. Fixes all the places that caused `Project` to be captured and uses a task registration workaround to capture project fields at the very last possible moment. Also removes the now deprecated `forUseAtConfigurationTime()` property accessors.

Watch for https://github.com/gradle/gradle/issues/19992, you can't capture plugin/extension fields in Groovy closures, they don't survive caching - and if you have a case like here where you need project.group/version/etc outside of the context of a plugin, `taskGraph.whenReady` looks like the last possible moment to get at those without having to jump through additional hoops (all of which I tried before I realised this was the simple answer).