### PR TITLE
refactor: avoid generating getters for "constants"

### DIFF
--- a/src/main/groovy/nebula/plugin/info/basic/BasicInfoPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/basic/BasicInfoPlugin.groovy
@@ -46,13 +46,13 @@ class BasicInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern('yyyy-MM-dd_HH:mm:ss')
     private static final DateTimeFormatter DATE_TIME_ISO_FORMATTER = DateTimeFormatter.ISO_ZONED_DATE_TIME
 
-    static final String BUILT_BY_PROPERTY = 'Built-By'
-    static final String BUILT_OS_PROPERTY = 'Built-OS'
-    static final String BUILD_DATE_PROPERTY = 'Build-Date'
-    static final String BUILD_DATE_UTC_PROPERTY = 'Build-Date-UTC'
-    static final String BUILD_TIMEZONE_PROPERTY = 'Build-Timezone'
-    static final String BUILD_STATUS_PROPERTY = 'Built-Status'
-    static final String GRADLE_VERSION_PROPERTY = 'Gradle-Version'
+    public static final String BUILT_BY_PROPERTY = 'Built-By'
+    public static final String BUILT_OS_PROPERTY = 'Built-OS'
+    public static final String BUILD_DATE_PROPERTY = 'Build-Date'
+    public static final String BUILD_DATE_UTC_PROPERTY = 'Build-Date-UTC'
+    public static final String BUILD_TIMEZONE_PROPERTY = 'Build-Timezone'
+    public static final String BUILD_STATUS_PROPERTY = 'Built-Status'
+    public static final String GRADLE_VERSION_PROPERTY = 'Gradle-Version'
 
     // Sample from commons-lang, and hence via Maven
     // Manifest-Version: 1.0

--- a/src/main/groovy/nebula/plugin/info/ci/ContinuousIntegrationInfoPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/ci/ContinuousIntegrationInfoPlugin.groovy
@@ -29,11 +29,11 @@ import javax.inject.Inject
 
 class ContinuousIntegrationInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
 
-    static final BUILD_HOST_PROPERTY = 'Build-Host'
-    static final BUILD_JOB_PROPERTY = 'Build-Job'
-    static final BUILD_NUMBER_PROPERTY = 'Build-Number'
-    static final BUILD_ID_PROPERTY = 'Build-Id'
-    static final BUILD_URL_PROPERTY = 'Build-Url'
+    public static final BUILD_HOST_PROPERTY = 'Build-Host'
+    public static final BUILD_JOB_PROPERTY = 'Build-Job'
+    public static final BUILD_NUMBER_PROPERTY = 'Build-Number'
+    public static final BUILD_ID_PROPERTY = 'Build-Id'
+    public static final BUILD_URL_PROPERTY = 'Build-Url'
 
     List<ContinuousIntegrationInfoProvider> providers
     ContinuousIntegrationInfoProvider selectedProvider

--- a/src/main/groovy/nebula/plugin/info/java/InfoJavaPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/java/InfoJavaPlugin.groovy
@@ -41,11 +41,11 @@ class InfoJavaPlugin implements Plugin<Project>, InfoCollectorPlugin {
     // Apache Commons has a standard convention for these variables
     // http://commons.apache.org/releases/prepare.html
 
-    static final String CREATED_PROPERTY = 'Created-By' // E.g. Created-By: 1.5.0_13-119 (Apple Inc.)
-    static final String JDK_PROPERTY = 'Build-Java-Version'
+    public static final String CREATED_PROPERTY = 'Created-By' // E.g. Created-By: 1.5.0_13-119 (Apple Inc.)
+    public static final String JDK_PROPERTY = 'Build-Java-Version'
 
-    static final String SOURCE_PROPERTY = 'X-Compile-Source-JDK'
-    static final String TARGET_PROPERTY = 'X-Compile-Target-JDK'
+    public static final String SOURCE_PROPERTY = 'X-Compile-Source-JDK'
+    public static final String TARGET_PROPERTY = 'X-Compile-Target-JDK'
 
     private final ProviderFactory providers
 

--- a/src/main/groovy/nebula/plugin/info/scm/ScmInfoPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/info/scm/ScmInfoPlugin.groovy
@@ -23,18 +23,16 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
-import org.gradle.api.logging.Logger
-import org.gradle.api.logging.Logging
 import org.gradle.api.provider.ProviderFactory
 
 import javax.inject.Inject
 
 class ScmInfoPlugin implements Plugin<Project>, InfoCollectorPlugin {
-    static final String MODULE_SOURCE_PROPERTY = 'Module-Source'
-    static final String MODULE_ORIGIN_PROPERTY = 'Module-Origin'
-    static final String CHANGE_PROPERTY = 'Change'
-    static final String FULL_CHANGE_PROPERTY = 'Full-Change'
-    static final String BRANCH_PROPERTY = 'Branch'
+    public static final String MODULE_SOURCE_PROPERTY = 'Module-Source'
+    public static final String MODULE_ORIGIN_PROPERTY = 'Module-Origin'
+    public static final String CHANGE_PROPERTY = 'Change'
+    public static final String FULL_CHANGE_PROPERTY = 'Full-Change'
+    public static final String BRANCH_PROPERTY = 'Branch'
 
     List<ScmInfoProvider> providers
     ScmInfoProvider selectedProvider


### PR DESCRIPTION
It is unlikely that the original intent was to expose getters such as `getBUILT_BY_PROPERTY()`, so change those properties to `public` fields, for the benefit of a clearer API, and more idiomatic integration with statically compiled languages.

https://docs.groovy-lang.org/docs/groovy-3.0.13/html/documentation/#_fields_and_properties

That change is source-compatible with existing dynamically compiled Groovy, but breaks compatibility with any statically compiled language (including Groovy with `@CompileStatic`): as the getters are removed, they now need to refer to the newly exposed fields.