### PR TITLE
Update build badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Gradle Info Plugin
 ![Support Status](https://img.shields.io/badge/nebula-active-green.svg)
 [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com.netflix.nebula/gradle-info-plugin/maven-metadata.xml.svg?label=gradlePluginPortal)](https://plugins.gradle.org/plugin/com.netflix.nebula.info)
 [![Maven Central](https://img.shields.io/maven-central/v/com.netflix.nebula/gradle-info-plugin)](https://maven-badges.herokuapp.com/maven-central/com.netflix.nebula/gradle-info-plugin)
-![Build](https://github.com/nebula-plugins/gradle-info-plugin/actions/workflows/nebula.yml/badge.svg)
+![Build](https://github.com/nebula-plugins/gradle-info-plugin/actions/workflows/build.yml/badge.svg)
 [![Apache 2.0](https://img.shields.io/github/license/nebula-plugins/gradle-info-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 Noninvasively collect information about the environment, and make information available to other plugins in a statically typed way. When possible lazily calculate info.


### PR DESCRIPTION
Hi, this updates the badge url to the `build.yml` workflow. I noticed the badge wasn't rendering because it referenced a non-existent workflow name.

<img width="682" height="198" alt="Screenshot_2026-06-27_08-50-13" src="https://github.com/user-attachments/assets/70281f11-b17d-4774-a8b7-8eae0b198ef9" />
